### PR TITLE
WIP: #72: A draft version of mertics based on ZIO-ZMX

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -56,6 +56,7 @@ lazy val core = project
     libraryDependencies ++= Seq(
       "dev.zio" %% "zio"         % zioVersion,
       "dev.zio" %% "zio-streams" % zioVersion,
-      "dev.zio" %% "zio-nio"     % zioNioVersion
+      "dev.zio" %% "zio-nio"     % zioNioVersion,
+      "dev.zio" %% "zio-zmx"     % zioZmxVersion
     )
   )

--- a/core/src/main/scala/zio/web/http/HttpMiddleware.scala
+++ b/core/src/main/scala/zio/web/http/HttpMiddleware.scala
@@ -2,6 +2,8 @@ package zio.web.http
 
 import zio._
 import java.nio.charset.StandardCharsets
+import zio.zmx.Metrics
+import zio.zmx._
 
 /**
  * An `HttpMiddleware[R, E]` value defines HTTP middleware that requires an
@@ -108,6 +110,21 @@ object HttpMiddleware {
               )
             }
         )
+    )
+
+  def metrics: HttpMiddleware[Metrics, Nothing] =
+    HttpMiddleware(
+      ZIO.succeed(
+        Middleware(
+          Request.none,
+          Response(
+            HttpResponse.StatusCode,
+            (_: Unit, statusCode: Int) =>
+              (zio.zmx.Metrics.increment("zio-web-requests", 1.0, Label("httpStatusCode", statusCode.toString)))
+                .as(HttpHeaders.empty)
+          )
+        )
+      )
     )
 
   /**


### PR DESCRIPTION
Adding a basic implementation of an increment counter that emits metrics to ZIO-ZMX labeling the events with HTTP Status code.

The code can be treated as an example of metrics API. The caveat here is that it brings ZIO-ZMX as a hardcoded dependency.

From my perspective, ZIO-Web should not rely on any particular implementation of metrics or tracing tools. I would suggest using Open Telemetry as an abstraction within ZIO-Web, so the end-user can choose which exporter and visualization tool to use. Exported, though, looks like a part of ZIO-ZMX.

