### PR TITLE
Add Protobuf codec

### DIFF
--- a/core/src/main/scala/zio/web/codec/ProtobufCodec.scala
+++ b/core/src/main/scala/zio/web/codec/ProtobufCodec.scala
@@ -131,7 +131,7 @@ object ProtobufCodec extends Codec {
 
     private def wireType(standardType: StandardType[_]): Int = standardType match {
       case StandardType.UnitType   => 0
-      case StandardType.StringType => 0
+      case StandardType.StringType => 2
       case StandardType.BoolType   => 0
       case StandardType.ShortType  => 0
       case StandardType.IntType    => 0

--- a/core/src/main/scala/zio/web/codec/ProtobufCodec.scala
+++ b/core/src/main/scala/zio/web/codec/ProtobufCodec.scala
@@ -60,10 +60,12 @@ object ProtobufCodec extends Codec {
       varInt(chunk.size) ++ chunk
     }
 
-    private def encodeSequence[A](element: Schema[A], chunk: Chunk[A]): Chunk[Byte] = {
+    // TODO packed
+    private def encodeSequence[A](element: Schema[A], sequence: Chunk[A]): Chunk[Byte] = {
       System.out.println("SEQ " + element)
-      System.out.println("SEQ " + chunk)
-      Chunk(100.byteValue()) // TODO
+      System.out.println("SEQ " + sequence)
+      val chunck = sequence.flatMap(value => encode(element, value))
+      varInt(chunck.size) ++ chunck
     }
 
     // TODO defaults

--- a/core/src/main/scala/zio/web/codec/ProtobufCodec.scala
+++ b/core/src/main/scala/zio/web/codec/ProtobufCodec.scala
@@ -1,0 +1,13 @@
+package zio.web.codec
+
+import zio.stream.ZTransducer
+import zio.web.schema._
+import zio.{ Chunk, ZIO, ZManaged }
+
+object ProtobufCodec extends Codec {
+  override def encoder[A](schema: Schema[A]): ZTransducer[Any, Nothing, A, Byte] =
+    ZTransducer(ZManaged.succeed(_ => ZIO.succeed(Chunk(0.byteValue()))))
+
+  override def decoder[A](schema: Schema[A]): ZTransducer[Any, String, Byte, A] =
+    ZTransducer(ZManaged.succeed(_ => ZIO.fail("Decoder not implemented")))
+}

--- a/core/src/main/scala/zio/web/codec/ProtobufCodec.scala
+++ b/core/src/main/scala/zio/web/codec/ProtobufCodec.scala
@@ -6,6 +6,8 @@ import zio.stream.ZTransducer
 import zio.web.schema._
 import zio.{ Chunk, ZIO, ZManaged }
 
+import scala.collection.SortedMap
+
 object ProtobufCodec extends Codec {
   override def encoder[A](schema: Schema[A]): ZTransducer[Any, Nothing, A, Byte] =
     ZTransducer(ZManaged.succeed(chunk => ZIO.succeed(Encoder.encodeChunk(schema, chunk))))
@@ -13,21 +15,30 @@ object ProtobufCodec extends Codec {
   override def decoder[A](schema: Schema[A]): ZTransducer[Any, String, Byte, A] =
     ZTransducer(ZManaged.succeed(chunk => ZIO.fail("Decoder not implemented: " + chunk)))
 
+  sealed trait WireType {}
+
+  case object VarInt                     extends WireType
+  case object Bit64                      extends WireType
+  case class LengthDelimited(width: Int) extends WireType
+  case object StartGroup                 extends WireType
+  case object EndGroup                   extends WireType
+  case object Bit32                      extends WireType
+
   object Encoder {
 
     def encodeChunk[A](schema: Schema[A], chunk: Option[Chunk[A]]): Chunk[Byte] =
-      chunk.map(_.flatMap(encode(schema, _))).getOrElse(Chunk.empty)
+      chunk.map(_.flatMap(encode(None, schema, _))).getOrElse(Chunk.empty)
 
-    private def encode[A](schema: Schema[A], value: A): Chunk[Byte] = {
+    private def encode[A](fieldNumber: Option[Int], schema: Schema[A], value: A): Chunk[Byte] = {
       System.out.println("ENCODE !!SCHEMA!! " + schema + "     !! VALUE !! " + value)
       (schema, value) match {
-        case (Schema.Record(structure), v: Map[String, _]) => encodeRecord(structure, v)
-        case (Schema.Sequence(element), v: Chunk[_])       => encodeSequence(element, v)
-        case (Schema.Enumeration(_), _)                    => Chunk(100.byteValue())
-        case (Schema.Transform(codec, _, g), _)            => g(value).map(encode(codec, _)).getOrElse(Chunk.empty)
-        case (Schema.Primitive(standardType), v)           => encodeStandardType(standardType, v)
-        case (Schema.Tuple(left, right), v @ (_, _))       => encodeTuple(left, right, v)
-        case (Schema.Optional(codec), v: Option[_])        => encodeOptional(codec, v)
+        case (Schema.Record(structure), v: SortedMap[String, _]) => encodeRecord(fieldNumber, structure, v)
+        case (Schema.Sequence(element), v: Chunk[_])             => encodeSequence(fieldNumber, element, v)
+        case (Schema.Enumeration(_), _)                          => Chunk.empty // TODO
+        case (Schema.Transform(codec, _, g), _)                  => g(value).map(encode(fieldNumber, codec, _)).getOrElse(Chunk.empty)
+        case (Schema.Primitive(standardType), v)                 => encodeStandardType(fieldNumber, standardType, v)
+        case (Schema.Tuple(left, right), v @ (_, _))             => encodeTuple(fieldNumber, left, right, v)
+        case (Schema.Optional(codec), v: Option[_])              => encodeOptional(fieldNumber, codec, v)
         case (_, _) => {
           System.out.println("skipping " + schema + " " + value)
           Chunk.empty
@@ -35,59 +46,70 @@ object ProtobufCodec extends Codec {
       }
     }
 
-    type FieldCodec[A] = (Schema[A], A)
-
-    private def encodeField(
-      structure: Map[String, Schema[_]],
-      data: Map[String, _],
-      field: String
-    ): Chunk[Byte] =
-      structure
-        .get(field)
-        .flatMap(schema => data.get(field).map(value => (schema.asInstanceOf[Schema[Any]], value)))
-        .map {
-          case (schema, value) =>
-            tag(schema, 1) ++ encode(schema, value)
-        }
-        .getOrElse(Chunk.empty)
-
     // TODO check: width only for non-root?
-    private def encodeRecord(structure: Map[String, Schema[_]], data: Map[String, _]): Chunk[Byte] = {
+    private def encodeRecord(
+      fieldNumber: Option[Int],
+      structure: SortedMap[String, Schema[_]],
+      data: SortedMap[String, _]
+    ): Chunk[Byte] = {
       System.out.println("RECORD " + structure)
       System.out.println("RECORD " + data)
-      val chunk = Chunk.fromIterable(data.keys.map(field => encodeField(structure, data, field))).flatten
-      System.out.println("RECORD chunk " + asHex(chunk))
-      varInt(chunk.size) ++ chunk
+      System.out.println("RECORD " + fieldNumber)
+      Chunk
+        .fromIterable(structure.zipWithIndex.map {
+          case ((field, schema), index) =>
+            data
+              .get(field)
+              .map(value => (schema.asInstanceOf[Schema[Any]], value))
+              .map {
+                case (schema, value) =>
+                  encode(Some(index + 1), schema, value)
+              }
+              .getOrElse(Chunk.empty)
+        })
+        .map(chunk => tag(LengthDelimited(chunk.size), fieldNumber) ++ chunk)
+        .flatten
     }
 
     // TODO packed
-    private def encodeSequence[A](element: Schema[A], sequence: Chunk[A]): Chunk[Byte] = {
+    private def encodeSequence[A](
+      fieldNumber: Option[Int],
+      element: Schema[A],
+      sequence: Chunk[A]
+    ): Chunk[Byte] = {
       System.out.println("SEQ " + element)
       System.out.println("SEQ " + sequence)
-      val chunck = sequence.flatMap(value => encode(element, value))
-      varInt(chunck.size) ++ chunck
+      if (packed(element)) {
+        val chunk = sequence.flatMap(value => encode(None, element, value))
+        tag(LengthDelimited(chunk.size), fieldNumber) ++ chunk
+      } else {
+        sequence.flatMap(value => encode(fieldNumber, element, value))
+      }
     }
 
     // TODO defaults
     // TODO varInts: 32, 64, unsigned, zigZag, fixed
-    private def encodeStandardType[A](standardType: StandardType[A], value: A): Chunk[Byte] = {
+    private def encodeStandardType[A](
+      fieldNumber: Option[Int],
+      standardType: StandardType[A],
+      value: A
+    ): Chunk[Byte] = {
       System.out.println("STANDARD " + value)
       (standardType, value) match {
         case (StandardType.UnitType, _) => Chunk.empty
         case (StandardType.StringType, str: String) => {
           val encoded = Chunk.fromArray(str.getBytes(Charset.forName("UTF-8"))) // TODO ZIO NIO?
-          val result  = varInt(encoded.size) ++ encoded
-          System.out.println("STRING " + str + " " + asHex(result))
-          result
+          tag(LengthDelimited(encoded.size), fieldNumber) ++ encoded
         }
-        case (StandardType.BoolType, b: Boolean)  => varInt(if (b) 1 else 0)
-        case (StandardType.ShortType, v: Short)   => varInt(v.toInt)
-        case (StandardType.IntType, v: Int)       => varInt(v)
-        case (StandardType.LongType, v: Long)     => varInt(v.toInt)
+        case (StandardType.BoolType, b: Boolean)  => tag(VarInt, fieldNumber) ++ varInt(if (b) 1 else 0)
+        case (StandardType.ShortType, v: Short)   => tag(VarInt, fieldNumber) ++ varInt(v.toLong)
+        case (StandardType.IntType, v: Int)       => tag(VarInt, fieldNumber) ++ varInt(v)
+        case (StandardType.LongType, v: Long)     => tag(VarInt, fieldNumber) ++ varInt(v)
         case (StandardType.FloatType, _: Float)   => Chunk.empty // TODO
         case (StandardType.DoubleType, _: Double) => Chunk.empty // TODO
-        case (StandardType.ByteType, byte: Byte)  => varInt(1) :+ byte // TODO must be Chunk[Byte]?
-        case (StandardType.CharType, _: Char)     => Chunk.empty // TODO
+        case (StandardType.ByteType, byte: Byte) =>
+          tag(LengthDelimited(1), fieldNumber) :+ byte // TODO must be Chunk[Byte]?
+        case (StandardType.CharType, c: Char) => encodeStandardType(fieldNumber, StandardType.StringType, c.toString)
         case (_, _) => {
           System.out.println("skipping " + standardType + " " + value)
           Chunk.empty
@@ -95,19 +117,29 @@ object ProtobufCodec extends Codec {
       }
     }
 
-    private def encodeTuple[A, B](left: Schema[A], right: Schema[B], tuple: (A, B)): Chunk[Byte] =
+    private def encodeTuple[A, B](
+      fieldNumber: Option[Int],
+      left: Schema[A],
+      right: Schema[B],
+      tuple: (A, B)
+    ): Chunk[Byte] =
       encode(
-        Schema.record(Map("left" -> left, "right" -> right)),
-        Map[String, Any]("left" -> tuple._1, "right" -> tuple._2)
+        fieldNumber,
+        Schema.record(SortedMap("left" -> left, "right" -> right)),
+        SortedMap[String, Any]("left" -> tuple._1, "right" -> tuple._2)
       )
 
-    private def encodeOptional[A](schema: Schema[A], value: Option[A]): Chunk[Byte] =
+    private def encodeOptional[A](fieldNumber: Option[Int], schema: Schema[A], value: Option[A]): Chunk[Byte] =
       encode(
-        Schema.record(Map("value" -> schema)),
-        Map("value" -> value)
+        fieldNumber,
+        Schema.record(SortedMap("value" -> schema)),
+        SortedMap("value" -> value)
       )
 
-    private def varInt(value: Int): Chunk[Byte] = {
+    private def varInt(value: Int): Chunk[Byte] =
+      varInt(value.toLong)
+
+    private def varInt(value: Long): Chunk[Byte] = {
       val base128    = value & 0x7F;
       val higherBits = value >>> 7;
       if (higherBits != 0x00) {
@@ -117,31 +149,40 @@ object ProtobufCodec extends Codec {
       }
     }
 
-    private def tag(schema: Schema[_], fieldNumber: Int): Chunk[Byte] =
-      varInt(fieldNumber << 3 | wireType(schema))
+    private def tag(wireType: WireType, fieldNumber: Option[Int]): Chunk[Byte] =
+      fieldNumber.map { num =>
+        val encodeTag = (base3: Int) => varInt(num << 3 | base3)
+        wireType match {
+          case VarInt                  => encodeTag(0)
+          case Bit64                   => encodeTag(1)
+          case LengthDelimited(length) => encodeTag(2) ++ varInt(length)
+          case StartGroup              => encodeTag(3)
+          case EndGroup                => encodeTag(4)
+          case Bit32                   => encodeTag(5)
+        }
+      }.getOrElse(Chunk.empty)
 
-    @scala.annotation.tailrec
-    private def wireType(schema: Schema[_]): Int = schema match {
-      case _: Schema.Record               => 2
-      case _: Schema.Sequence[_]          => 2
-      case _: Schema.Enumeration          => 2
-      case Schema.Transform(codec, _, _)  => wireType(codec)
-      case Schema.Primitive(standardType) => wireType(standardType)
-      case _: Schema.Tuple[_, _]          => 2
-      case _: Schema.Optional[_]          => 2
+    private def packed(schema: Schema[_]): Boolean = schema match {
+      case _: Schema.Record               => false
+      case Schema.Sequence(element)       => packed(element)
+      case _: Schema.Enumeration          => false
+      case Schema.Transform(codec, _, _)  => packed(codec)
+      case Schema.Primitive(standardType) => packed(standardType)
+      case _: Schema.Tuple[_, _]          => false
+      case _: Schema.Optional[_]          => false
     }
 
-    private def wireType(standardType: StandardType[_]): Int = standardType match {
-      case StandardType.UnitType   => 0
-      case StandardType.StringType => 2
-      case StandardType.BoolType   => 0
-      case StandardType.ShortType  => 0
-      case StandardType.IntType    => 0
-      case StandardType.LongType   => 0
-      case StandardType.FloatType  => 5
-      case StandardType.DoubleType => 1
-      case StandardType.ByteType   => 2
-      case StandardType.CharType   => 2
+    private def packed(standardType: StandardType[_]): Boolean = standardType match {
+      case StandardType.UnitType   => false
+      case StandardType.StringType => false
+      case StandardType.BoolType   => true
+      case StandardType.ShortType  => true
+      case StandardType.IntType    => true
+      case StandardType.LongType   => true
+      case StandardType.FloatType  => true
+      case StandardType.DoubleType => true
+      case StandardType.ByteType   => false
+      case StandardType.CharType   => true
     }
 
     // TODO remove: for debugging only

--- a/core/src/main/scala/zio/web/codec/ProtobufCodec.scala
+++ b/core/src/main/scala/zio/web/codec/ProtobufCodec.scala
@@ -6,8 +6,134 @@ import zio.{ Chunk, ZIO, ZManaged }
 
 object ProtobufCodec extends Codec {
   override def encoder[A](schema: Schema[A]): ZTransducer[Any, Nothing, A, Byte] =
-    ZTransducer(ZManaged.succeed(_ => ZIO.succeed(Chunk(0.byteValue()))))
+    ZTransducer(ZManaged.succeed(chunk => ZIO.succeed(Encoder.encodeChunk(schema, chunk))))
 
   override def decoder[A](schema: Schema[A]): ZTransducer[Any, String, Byte, A] =
-    ZTransducer(ZManaged.succeed(_ => ZIO.fail("Decoder not implemented")))
+    ZTransducer(ZManaged.succeed(chunk => ZIO.fail("Decoder not implemented: " + chunk)))
+
+  object Encoder {
+
+    def encodeChunk[A](schema: Schema[A], chunk: Option[Chunk[A]]): Chunk[Byte] =
+      chunk.map(_.flatMap(encode(schema, _))).getOrElse(Chunk.empty)
+
+    private def encode[A](schema: Schema[A], value: A): Chunk[Byte] = {
+      System.out.println("ENCODE !!SCHEMA!! " + schema + "     !! VALUE !! " + value)
+      (schema, value) match {
+        case (Schema.Record(structure), v: Map[String, _]) => encodeRecord(structure, v)
+        case (Schema.Sequence(element), v: Chunk[_])       => encodeSequence(element, v)
+        case (Schema.Enumeration(_), _)                    => Chunk(100.byteValue())
+        case (Schema.Transform(codec, _, g), _)            => g(value).map(encode(codec, _)).getOrElse(Chunk.empty)
+        case (Schema.Primitive(standardType), v)           => encodeStandardType(standardType, v)
+        case (Schema.Tuple(left, right), v @ (_, _))       => encodeTuple(left, right, v)
+        case (Schema.Optional(codec), v: Option[_])        => encodeOptional(codec, v)
+        case (_, _) => {
+          System.out.println("skipping " + schema + " " + value)
+          Chunk.empty
+        }
+      }
+    }
+
+    type FieldCodec[A] = (Schema[A], A)
+
+    private def encodeField(
+      structure: Map[String, Schema[_]],
+      data: Map[String, _],
+      field: String
+    ): Chunk[Byte] =
+      structure
+        .get(field)
+        .flatMap(schema => data.get(field).map(value => (schema.asInstanceOf[Schema[Any]], value)))
+        .map {
+          case (schema, value) =>
+            tag(schema, 1) ++ encode(schema, value)
+        }
+        .getOrElse(Chunk.empty)
+
+    private def encodeRecord(structure: Map[String, Schema[_]], data: Map[String, _]): Chunk[Byte] = {
+      System.out.println("RECORD " + structure)
+      System.out.println("RECORD " + data)
+      val chunk = Chunk.fromIterable(data.keys.flatMap(field => encodeField(structure, data, field)))
+      varInt(chunk.size) ++ chunk
+    }
+
+    private def encodeSequence[A](element: Schema[A], chunk: Chunk[A]): Chunk[Byte] = {
+      System.out.println("SEQ " + element)
+      System.out.println("SEQ " + chunk)
+      Chunk(100.byteValue()) // TODO
+    }
+
+    // TODO defaults
+    // TODO varInts: 32, 64, unsigned, zigZag
+    private def encodeStandardType[A](standardType: StandardType[A], value: A): Chunk[Byte] = {
+      System.out.println("STANDARD " + value)
+      (standardType, value) match {
+        case (StandardType.UnitType, _) => Chunk.empty
+        case (StandardType.StringType, str: String) => {
+          val encoded = Chunk.fromArray(str.getBytes);
+          varInt(encoded.size) ++ encoded
+        }
+        case (StandardType.BoolType, b: Boolean)  => varInt(if (b) 1 else 0)
+        case (StandardType.ShortType, v: Short)   => varInt(v.toInt)
+        case (StandardType.IntType, v: Int)       => varInt(v)
+        case (StandardType.LongType, v: Long)     => varInt(v.toInt)
+        case (StandardType.FloatType, _: Float)   => Chunk.empty // TODO
+        case (StandardType.DoubleType, _: Double) => Chunk.empty // TODO
+        case (StandardType.ByteType, byte: Byte)  => varInt(1) :+ byte // TODO must be Chunk[Byte]?
+        case (StandardType.CharType, _: Char)     => Chunk.empty // TODO
+        case (_, _) => {
+          System.out.println("skipping " + standardType + " " + value)
+          Chunk.empty
+        }
+      }
+    }
+
+    private def encodeTuple[A, B](left: Schema[A], right: Schema[B], tuple: (A, B)): Chunk[Byte] =
+      encode(
+        Schema.record(Map("left" -> left, "right" -> right)),
+        Map[String, Any]("left" -> tuple._1, "right" -> tuple._2)
+      )
+
+    private def encodeOptional[A](schema: Schema[A], value: Option[A]): Chunk[Byte] =
+      encode(
+        Schema.record(Map("value" -> schema)),
+        Map("value" -> value)
+      )
+
+    private def varInt(value: Int): Chunk[Byte] = {
+      val base128    = value & 0x7F;
+      val higherBits = value >>> 7;
+      if (higherBits != 0x00) {
+        (0x80 | base128).byteValue() +: varInt(higherBits)
+      } else {
+        Chunk(base128.byteValue())
+      }
+    }
+
+    private def tag(schema: Schema[_], fieldNumber: Int): Chunk[Byte] =
+      varInt(fieldNumber << 3 | wireType(schema))
+
+    @scala.annotation.tailrec
+    private def wireType(schema: Schema[_]): Int = schema match {
+      case _: Schema.Record               => 2
+      case _: Schema.Sequence[_]          => 2
+      case _: Schema.Enumeration          => 2
+      case Schema.Transform(codec, _, _)  => wireType(codec)
+      case Schema.Primitive(standardType) => wireType(standardType)
+      case _: Schema.Tuple[_, _]          => 2
+      case _: Schema.Optional[_]          => 2
+    }
+
+    private def wireType(standardType: StandardType[_]): Int = standardType match {
+      case StandardType.UnitType   => 0
+      case StandardType.StringType => 0
+      case StandardType.BoolType   => 0
+      case StandardType.ShortType  => 0
+      case StandardType.IntType    => 0
+      case StandardType.LongType   => 0
+      case StandardType.FloatType  => 5
+      case StandardType.DoubleType => 1
+      case StandardType.ByteType   => 2
+      case StandardType.CharType   => 2
+    }
+  }
 }

--- a/core/src/main/scala/zio/web/schema/StandardType.scala
+++ b/core/src/main/scala/zio/web/schema/StandardType.scala
@@ -1,5 +1,7 @@
 package zio.web.schema
 
+import zio.Chunk
+
 sealed trait StandardType[A]
 
 object StandardType {
@@ -11,7 +13,7 @@ object StandardType {
   implicit object LongType   extends StandardType[Long]
   implicit object FloatType  extends StandardType[Float]
   implicit object DoubleType extends StandardType[Double]
-  implicit object ByteType   extends StandardType[Byte]
+  implicit object ByteType   extends StandardType[Chunk[Byte]]
   implicit object CharType   extends StandardType[Char]
 
   // TODO: Add java.time

--- a/core/src/test/scala/zio/web/codec/ProtobufCodecSpec.scala
+++ b/core/src/test/scala/zio/web/codec/ProtobufCodecSpec.scala
@@ -46,7 +46,7 @@ object ProtobufCodecSpec extends DefaultRunnableSpec {
         )
       },
       testM("Should encode and decode successfully") {
-        assertM(encodeAndDecode(schema, message).fold(identity, _ => "SUCCESS"))(
+        assertM(encodeAndDecode(schema, message).fold(identity, _.toString()))(
           equalTo("TODO")
         )
       }

--- a/core/src/test/scala/zio/web/codec/ProtobufCodecSpec.scala
+++ b/core/src/test/scala/zio/web/codec/ProtobufCodecSpec.scala
@@ -17,7 +17,12 @@ object ProtobufCodecSpec extends DefaultRunnableSpec {
       },
       testM("Should encode Protobuf Test2 correctly") {
         assertM(encode(schemaTest2, Test2("testing")).map(asHex))(
-          equalTo("0x09080774657374696E67")
+          equalTo("0x090A0774657374696E67")
+        )
+      },
+      testM("Should encode Protobuf Test3 correctly") {
+        assertM(encode(schemaTest3, Test3(Test1(150))).map(asHex))(
+          equalTo("0x050A03089601")
         )
       },
       testM("Should encode and decode successfully") {
@@ -29,6 +34,7 @@ object ProtobufCodecSpec extends DefaultRunnableSpec {
   )
 
   // see https://developers.google.com/protocol-buffers/docs/encoding
+  // note that unlike the protobuf test cases we always get field number 1
 
   case class Test1(a: Int)
 
@@ -41,6 +47,12 @@ object ProtobufCodecSpec extends DefaultRunnableSpec {
   val schemaTest2: Schema[Test2] = Schema.caseClassN(
     "b" -> Schema[String]
   )(Test2, Test2.unapply)
+
+  case class Test3(c: Test1)
+
+  val schemaTest3: Schema[Test3] = Schema.caseClassN(
+    "c" -> schemaTest1
+  )(Test3, Test3.unapply)
 
   // TODO Generators
 

--- a/core/src/test/scala/zio/web/codec/ProtobufCodecSpec.scala
+++ b/core/src/test/scala/zio/web/codec/ProtobufCodecSpec.scala
@@ -25,6 +25,11 @@ object ProtobufCodecSpec extends DefaultRunnableSpec {
           equalTo("0x050A03089601")
         )
       },
+      testM("Should encode Protobuf Test4 correctly") {
+        assertM(encode(schemaTest4, Test4(List(3, 270, 86942))).map(asHex))(
+          equalTo("0x080A06038E029EA705")
+        )
+      },
       testM("Should encode and decode successfully") {
         assertM(encodeAndDecode(schema, message).fold(identity, _ => "SUCCESS"))(
           equalTo("TODO")
@@ -53,6 +58,12 @@ object ProtobufCodecSpec extends DefaultRunnableSpec {
   val schemaTest3: Schema[Test3] = Schema.caseClassN(
     "c" -> schemaTest1
   )(Test3, Test3.unapply)
+
+  case class Test4(d: List[Int])
+
+  val schemaTest4: Schema[Test4] = Schema.caseClassN(
+    "d" -> Schema.list(Schema[Int])
+  )(Test4, Test4.unapply)
 
   // TODO Generators
 

--- a/core/src/test/scala/zio/web/codec/ProtobufCodecSpec.scala
+++ b/core/src/test/scala/zio/web/codec/ProtobufCodecSpec.scala
@@ -7,13 +7,42 @@ import zio.test._
 import zio.web.schema.Schema
 
 object ProtobufCodecSpec extends DefaultRunnableSpec {
+
+  def spec = suite("ProtobufCodec Spec")(
+    suite("Toplevel ProtobufCodec Spec")(
+      testM("Should encode Protobuf Test1 correctly") {
+        assertM(encode(schemaTest1, Test1(150)).map(asHex))(
+          equalTo("0x03089601")
+        )
+      },
+      testM("Should encode Protobuf Test2 correctly") {
+        assertM(encode(schemaTest2, Test2("testing")).map(asHex))(
+          equalTo("0x09080774657374696E67")
+        )
+      },
+      testM("Should encode and decode successfully") {
+        assertM(encodeAndDecode(schema, message).fold(identity, _ => "SUCCESS"))(
+          equalTo("TODO")
+        )
+      }
+    )
+  )
+
+  // see https://developers.google.com/protocol-buffers/docs/encoding
+
   case class Test1(a: Int)
 
   val schemaTest1: Schema[Test1] = Schema.caseClassN(
     "a" -> Schema[Int]
   )(Test1, Test1.unapply)
 
-  val test1 = Test1(150)
+  case class Test2(b: String)
+
+  val schemaTest2: Schema[Test2] = Schema.caseClassN(
+    "b" -> Schema[String]
+  )(Test2, Test2.unapply)
+
+  // TODO Generators
 
   case class SearchRequest(query: String, pageNumber: Int, resultPerPage: Int)
 
@@ -24,21 +53,6 @@ object ProtobufCodecSpec extends DefaultRunnableSpec {
   )(SearchRequest, SearchRequest.unapply)
 
   val message: SearchRequest = SearchRequest("bitcoins", 0, 100)
-
-  def spec = suite("ProtobufCodec Spec")(
-    suite("Toplevel ProtobufCodec Spec")(
-      testM("Should encode correctly") {
-        assertM(encode(schemaTest1, test1).map(asHex))(
-          equalTo("0x03089601")
-        )
-      },
-      testM("Should encode and decode successfully") {
-        assertM(encodeAndDecode(schema, message).fold(identity, _ => "SUCCESS"))(
-          equalTo("TODO")
-        )
-      }
-    )
-  )
 
   def asHex(chunk: Chunk[Byte]): String =
     "0x" + chunk.toArray.map("%02X".format(_)).mkString

--- a/core/src/test/scala/zio/web/codec/ProtobufCodecSpec.scala
+++ b/core/src/test/scala/zio/web/codec/ProtobufCodecSpec.scala
@@ -54,6 +54,16 @@ object ProtobufCodecSpec extends DefaultRunnableSpec {
         assertM(encodeAndDecode(schema, message))(
           equalTo(Chunk(message))
         )
+      },
+      testM("Should encode and decode successfully PACKED") {
+        assertM(encodeAndDecode(schemaPackedList, PackedList(List(3, 270, 86942))))(
+          equalTo(Chunk(PackedList(List(3, 270, 86942))))
+        )
+      },
+      testM("Should encode and decode successfully NON-PACKED") {
+        assertM(encodeAndDecode(schemaUnpackedList, UnpackedList(List("foo", "bar", "baz"))))(
+          equalTo(Chunk(UnpackedList(List("foo", "bar", "baz"))))
+        )
       }
     )
   )

--- a/core/src/test/scala/zio/web/codec/ProtobufCodecSpec.scala
+++ b/core/src/test/scala/zio/web/codec/ProtobufCodecSpec.scala
@@ -45,9 +45,14 @@ object ProtobufCodecSpec extends DefaultRunnableSpec {
           equalTo("0x0A03666F6F0A036261720A0362617A")
         )
       },
+      testM("Should correctly encode records") {
+        assertM(encode(schemaRecord, Record("Foo", 123)).map(asHex))(
+          equalTo("0x0A03466F6F107B")
+        )
+      },
       testM("Should encode and decode successfully") {
-        assertM(encodeAndDecode(schema, message).fold(identity, _.toString()))(
-          equalTo("TODO")
+        assertM(encodeAndDecode(schema, message))(
+          equalTo(Chunk(message))
         )
       }
     )
@@ -97,8 +102,14 @@ object ProtobufCodecSpec extends DefaultRunnableSpec {
     "items" -> Schema.list(Schema[String])
   )(UnpackedList, UnpackedList.unapply)
 
-  // TODO Generators
+  case class Record(name: String, value: Int)
 
+  val schemaRecord: Schema[Record] = Schema.caseClassN(
+    "name"  -> Schema[String],
+    "value" -> Schema[Int]
+  )(Record, Record.unapply)
+
+  // TODO: Generators instead of SearchRequest
   case class SearchRequest(query: String, pageNumber: Int, resultPerPage: Int)
 
   val schema: Schema[SearchRequest] = Schema.caseClassN(
@@ -107,7 +118,7 @@ object ProtobufCodecSpec extends DefaultRunnableSpec {
     "resultPerPage" -> Schema[Int]
   )(SearchRequest, SearchRequest.unapply)
 
-  val message: SearchRequest = SearchRequest("bitcoins", 0, 100)
+  val message: SearchRequest = SearchRequest("bitcoins", 1, 100)
 
   def asHex(chunk: Chunk[Byte]): String =
     "0x" + chunk.toArray.map("%02X".format(_)).mkString

--- a/core/src/test/scala/zio/web/codec/ProtobufCodecSpec.scala
+++ b/core/src/test/scala/zio/web/codec/ProtobufCodecSpec.scala
@@ -7,6 +7,14 @@ import zio.test._
 import zio.web.schema.Schema
 
 object ProtobufCodecSpec extends DefaultRunnableSpec {
+  case class Test1(a: Int)
+
+  val schemaTest1: Schema[Test1] = Schema.caseClassN(
+    "a" -> Schema[Int]
+  )(Test1, Test1.unapply)
+
+  val test1 = Test1(150)
+
   case class SearchRequest(query: String, pageNumber: Int, resultPerPage: Int)
 
   val schema: Schema[SearchRequest] = Schema.caseClassN(
@@ -19,13 +27,27 @@ object ProtobufCodecSpec extends DefaultRunnableSpec {
 
   def spec = suite("ProtobufCodec Spec")(
     suite("Toplevel ProtobufCodec Spec")(
+      testM("Should encode correctly") {
+        assertM(encode(schemaTest1, test1).map(asHex))(
+          equalTo("0x03089601")
+        )
+      },
       testM("Should encode and decode successfully") {
-        assertM(encodeAndDecode(schema, message))(
-          equalTo(Chunk(message))
+        assertM(encodeAndDecode(schema, message).fold(identity, _ => "SUCCESS"))(
+          equalTo("TODO")
         )
       }
     )
   )
+
+  def asHex(chunk: Chunk[Byte]): String =
+    "0x" + chunk.toArray.map("%02X".format(_)).mkString
+
+  def encode[A](schema: Schema[A], input: A) =
+    ZStream
+      .succeed(input)
+      .transduce(ProtobufCodec.encoder(schema))
+      .run(ZSink.collectAll)
 
   def encodeAndDecode[A](schema: Schema[A], input: A) =
     ZStream

--- a/core/src/test/scala/zio/web/codec/ProtobufCodecSpec.scala
+++ b/core/src/test/scala/zio/web/codec/ProtobufCodecSpec.scala
@@ -20,6 +20,16 @@ object ProtobufCodecSpec extends DefaultRunnableSpec {
           equalTo("0x0A0774657374696E67")
         )
       },
+      testM("Should correctly encode floats") {
+        assertM(encode(schemaBasicFloat, BasicFloat(0.001f)).map(asHex))(
+          equalTo("0x0D6F12833A")
+        )
+      },
+      testM("Should correctly encode doubles") {
+        assertM(encode(schemaBasicDouble, BasicDouble(0.001)).map(asHex))(
+          equalTo("0x09FCA9F1D24D62503F")
+        )
+      },
       testM("Should correctly encode embedded messages") {
         assertM(encode(schemaEmbedded, Embedded(BasicInt(150))).map(asHex))(
           equalTo("0x0A03089601")
@@ -56,6 +66,18 @@ object ProtobufCodecSpec extends DefaultRunnableSpec {
   val schemaBasicString: Schema[BasicString] = Schema.caseClassN(
     "value" -> Schema[String]
   )(BasicString, BasicString.unapply)
+
+  case class BasicFloat(value: Float)
+
+  val schemaBasicFloat: Schema[BasicFloat] = Schema.caseClassN(
+    "value" -> Schema[Float]
+  )(BasicFloat, BasicFloat.unapply)
+
+  case class BasicDouble(value: Double)
+
+  val schemaBasicDouble: Schema[BasicDouble] = Schema.caseClassN(
+    "value" -> Schema[Double]
+  )(BasicDouble, BasicDouble.unapply)
 
   case class Embedded(embedded: BasicInt)
 

--- a/core/src/test/scala/zio/web/codec/ProtobufCodecSpec.scala
+++ b/core/src/test/scala/zio/web/codec/ProtobufCodecSpec.scala
@@ -1,0 +1,36 @@
+package zio.web.codec
+
+import zio.Chunk
+import zio.stream.{ ZSink, ZStream }
+import zio.test.Assertion._
+import zio.test._
+import zio.web.schema.Schema
+
+object ProtobufCodecSpec extends DefaultRunnableSpec {
+  case class SearchRequest(query: String, pageNumber: Int, resultPerPage: Int)
+
+  val schema: Schema[SearchRequest] = Schema.caseClassN(
+    "query"         -> Schema[String],
+    "pageNumber"    -> Schema[Int],
+    "resultPerPage" -> Schema[Int]
+  )(SearchRequest, SearchRequest.unapply)
+
+  val message: SearchRequest = SearchRequest("bitcoins", 0, 100)
+
+  def spec = suite("ProtobufCodec Spec")(
+    suite("Toplevel ProtobufCodec Spec")(
+      testM("Should encode and decode successfully") {
+        assertM(encodeAndDecode(schema, message))(
+          equalTo(Chunk(message))
+        )
+      }
+    )
+  )
+
+  def encodeAndDecode[A](schema: Schema[A], input: A) =
+    ZStream
+      .succeed(input)
+      .transduce(ProtobufCodec.encoder(schema))
+      .transduce(ProtobufCodec.decoder(schema))
+      .run(ZSink.collectAll)
+}


### PR DESCRIPTION
This PR adds a Protobuf Codec for encoding & decoding Protobuf byte chunks to/from `Schema`s (fixes #75).
The `Map`s in `Schema` have been replaced by `SortedMap` as we need guarantees on keeping the order of the field intact as Protobuf uses these as so-called _field numbers_.

Unfortunately, I won't be able to finish it during the hackaton, but I can complete it later. It would be nice to receive some initial feedback already.

These are the incomplete parts:

- [x] Add support for `Enumeration`
- [x] Handle decoding sequences
- [ ] Add property based testing for the encoding/decoding round-trip
- [x] (Handle missing values, i.e. use a default for primitives)

Open for discussion:

- Should `ByteType` not be a `StandardType[Chunk[Byte]]` instead of `StandardType[Byte]`?
- I think the generation of the `.proto` file should not be part of the `ProtobufCodec`, but rather something like a `ProtobufWriter` which could be used by a `GrpcWriter`. I suggest creating a seperate ticket for this.
- For now, all `Int`s are encoded as signed [var integers](https://developers.google.com/protocol-buffers/docs/encoding#varints) (int32, int64). However, Protobuf also provides alternatives which may be better suited when handling (mostly) non-zero or huge numbers. I suggest the default is OK for now but it might be interesting to make this configurable at a later stage).
- I noticed I used `asInstanceOf` quite a lot. Is there a way to make Scala directly understand what's going on here?