### PR TITLE
Add run methods for request and response

### DIFF
--- a/core/src/main/scala/zio/web/http/HttpRequest.scala
+++ b/core/src/main/scala/zio/web/http/HttpRequest.scala
@@ -1,5 +1,7 @@
 package zio.web.http
 
+import java.net.URI
+
 sealed trait HttpRequest[+A] { self =>
   def <>[A1 >: A](that: HttpRequest[A1]): HttpRequest[A1] = self.orElse(that)
 
@@ -10,27 +12,57 @@ sealed trait HttpRequest[+A] { self =>
 
   def orElseEither[B](that: HttpRequest[B]): HttpRequest[Either[A, B]] = HttpRequest.OrElseEither(self, that)
 
+  def run(method: String, uri: java.net.URI, headers: HttpHeaders): Option[A]
+
   def zip[B](that: HttpRequest[B]): HttpRequest[(A, B)] = HttpRequest.Zip(self, that)
 
   def zipWith[B, C](that: HttpRequest[B])(f: (A, B) => C): HttpRequest[C] = self.zip(that).map(f.tupled)
 }
 
 object HttpRequest {
-  sealed trait Scheme
-
-  object Scheme {
-    case object Any                         extends Scheme
-    final case class Specific(name: String) extends Scheme
+  case object Succeed extends HttpRequest[Unit] {
+    def run(method: String, uri: java.net.URI, headers: HttpHeaders): Option[Unit] = Some(())
   }
-  sealed trait SchemeSpecific
-  sealed trait Fragment
 
-  case object Succeed                                                              extends HttpRequest[Unit]
-  case object Fail                                                                 extends HttpRequest[Nothing]
-  case object Method                                                               extends HttpRequest[String]
-  final case class Header(name: String)                                            extends HttpRequest[String]
-  final case object URI                                                            extends HttpRequest[java.net.URI]
-  final case class Map[A, B](request: HttpRequest[A], f: A => B)                   extends HttpRequest[B]
-  final case class OrElseEither[A, B](left: HttpRequest[A], right: HttpRequest[B]) extends HttpRequest[Either[A, B]]
-  final case class Zip[A, B](left: HttpRequest[A], right: HttpRequest[B])          extends HttpRequest[(A, B)]
+  case object Fail extends HttpRequest[Nothing] {
+    def run(method: String, uri: java.net.URI, headers: HttpHeaders): Option[Nothing] = None
+  }
+
+  case object Method extends HttpRequest[String] {
+    def run(method: String, uri: java.net.URI, headers: HttpHeaders): Option[String] = Some(method)
+  }
+
+  final case class Header(name: String) extends HttpRequest[String] {
+
+    def run(method: String, uri: java.net.URI, headers: HttpHeaders): Option[String] =
+      headers.value.get(name)
+  }
+
+  final case object URI extends HttpRequest[java.net.URI] {
+    def run(method: String, uri: java.net.URI, headers: HttpHeaders): Option[URI] = Some(uri)
+  }
+
+  final case class Map[A, B](request: HttpRequest[A], f: A => B) extends HttpRequest[B] {
+
+    def run(method: String, uri: java.net.URI, headers: HttpHeaders): Option[B] =
+      request.run(method, uri, headers).map(f)
+  }
+
+  final case class OrElseEither[A, B](left: HttpRequest[A], right: HttpRequest[B]) extends HttpRequest[Either[A, B]] {
+
+    def run(method: String, uri: java.net.URI, headers: HttpHeaders): Option[Either[A, B]] = {
+      val l = left.run(method, uri, headers)
+      val r = right.run(method, uri, headers)
+      l.map(Left(_)).orElse(r.map(Right(_)))
+    }
+  }
+
+  final case class Zip[A, B](left: HttpRequest[A], right: HttpRequest[B]) extends HttpRequest[(A, B)] {
+
+    def run(method: String, uri: java.net.URI, headers: HttpHeaders): Option[(A, B)] =
+      for {
+        l <- left.run(method, uri, headers)
+        r <- right.run(method, uri, headers)
+      } yield (l, r)
+  }
 }

--- a/core/src/main/scala/zio/web/http/HttpResponse.scala
+++ b/core/src/main/scala/zio/web/http/HttpResponse.scala
@@ -10,17 +10,50 @@ sealed trait HttpResponse[+A] { self =>
 
   def orElseEither[B](that: HttpResponse[B]): HttpResponse[Either[A, B]] = HttpResponse.OrElseEither(self, that)
 
+  def run(statusCode: Int, headers: HttpHeaders): Option[A]
+
   def zip[B](that: HttpResponse[B]): HttpResponse[(A, B)] = HttpResponse.Zip(self, that)
 
   def zipWith[B, C](that: HttpResponse[B])(f: (A, B) => C): HttpResponse[C] = self.zip(that).map(f.tupled)
 }
 
 object HttpResponse {
-  case object Succeed                                                                extends HttpResponse[Unit]
-  case object Fail                                                                   extends HttpResponse[Nothing]
-  final case object StatusCode                                                       extends HttpResponse[Int]
-  final case class Header(name: String)                                              extends HttpResponse[String]
-  final case class Map[A, B](request: HttpResponse[A], f: A => B)                    extends HttpResponse[B]
-  final case class OrElseEither[A, B](left: HttpResponse[A], right: HttpResponse[B]) extends HttpResponse[Either[A, B]]
-  final case class Zip[A, B](left: HttpResponse[A], right: HttpResponse[B])          extends HttpResponse[(A, B)]
+  case object Succeed extends HttpResponse[Unit] {
+    def run(statusCode: Int, headers: HttpHeaders): Option[Unit] = Some(())
+  }
+
+  case object Fail extends HttpResponse[Nothing] {
+    def run(statusCode: Int, headers: HttpHeaders): Option[Nothing] = None
+  }
+
+  final case object StatusCode extends HttpResponse[Int] {
+    def run(statusCode: Int, headers: HttpHeaders): Option[Int] = Some(statusCode)
+  }
+
+  final case class Header(name: String) extends HttpResponse[String] {
+    def run(statusCode: Int, headers: HttpHeaders): Option[String] = headers.value.get(name)
+  }
+
+  final case class Map[A, B](response: HttpResponse[A], f: A => B) extends HttpResponse[B] {
+    def run(statusCode: Int, headers: HttpHeaders): Option[B] = response.run(statusCode, headers).map(f)
+  }
+
+  final case class OrElseEither[A, B](left: HttpResponse[A], right: HttpResponse[B])
+      extends HttpResponse[Either[A, B]] {
+
+    def run(statusCode: Int, headers: HttpHeaders): Option[Either[A, B]] = {
+      val l = left.run(statusCode, headers)
+      val r = right.run(statusCode, headers)
+      l.map(Left(_)).orElse(r.map(Right(_)))
+    }
+  }
+
+  final case class Zip[A, B](left: HttpResponse[A], right: HttpResponse[B]) extends HttpResponse[(A, B)] {
+
+    def run(statusCode: Int, headers: HttpHeaders): Option[(A, B)] =
+      for {
+        l <- left.run(statusCode, headers)
+        r <- right.run(statusCode, headers)
+      } yield (l, r)
+  }
 }

--- a/core/src/main/scala/zio/web/http/Patch.scala
+++ b/core/src/main/scala/zio/web/http/Patch.scala
@@ -1,0 +1,18 @@
+package zio.web.http
+
+import zio.web.http.model.StatusCode
+
+sealed trait Patch { self =>
+  def +(that: Patch): Patch = Patch.Combine(self, that)
+}
+
+object Patch {
+  private[zio] case object Empty                                   extends Patch
+  final private[zio] case class AddHeaders(headers: HttpHeaders)   extends Patch
+  final private[zio] case class SetStatus(status: StatusCode)      extends Patch
+  final private[zio] case class Combine(left: Patch, right: Patch) extends Patch
+
+  val empty: Patch                            = Empty
+  def addHeaders(headers: HttpHeaders): Patch = AddHeaders(headers)
+  def setStatus(status: StatusCode): Patch    = SetStatus(status)
+}


### PR DESCRIPTION
This PR adds run methods to request and response so we can execute them in tests.  This also adds `Patch` to allow the `processor` in `Response` to modify headers and status codes. 