### PR TITLE
Fix CircleCI build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -72,13 +72,21 @@ load_cache: &load_cache
   - restore_cache:
       key: sbt-http-cache-v2
 
+# TODO remove this after the build is fixed
+fix_cache: &fix_cache
+  - run:
+      name: Clean unwanted but previously already cached files (TODO remove this after the build is fixed)
+      command: |
+        find $HOME/.sbt/1.0/staging -maxdepth 2 -mindepth 2 -name zio-schema -type d -print -exec rm -rf {} +
+
 clean_cache: &clean_cache
   - run:
-      name: Clean unwanted files from cache
+      name: Clean unwanted files from cache (TODO remove the zio-schema related line, if it is not a source dependency any more)
       command: |
         rm -fv $HOME/.ivy2/.sbt.ivy.lock
         find $HOME/.ivy2/cache -name "ivydata-*.properties" -print -delete
         find $HOME/.sbt        -name "*.lock"               -print -delete
+        find $HOME/.sbt/1.0/staging -maxdepth 2 -mindepth 2 -name zio-schema -type d -print -exec rm -rf {} +
 
 save_cache: &save_cache
   - save_cache:
@@ -94,6 +102,8 @@ lint: &lint
   steps:
     - checkout
     - <<: *load_cache
+    # TODO remove this after the build is fixed
+    - <<: *fix_cache
     - run:
         name: Lint code
         command: ./sbt ++${SCALA_VERSION}! check
@@ -104,6 +114,8 @@ mdoc: &mdoc
   steps:
     - checkout
     - <<: *load_cache
+    # TODO remove this after the build is fixed
+    - <<: *fix_cache
     - run:
         name: Generate documentation
         command: |
@@ -116,6 +128,8 @@ test: &test
   steps:
     - checkout
     - <<: *load_cache
+    # TODO remove this after the build is fixed
+    - <<: *fix_cache
     - <<: *install_jdk
     - run:
         name: Run tests
@@ -130,6 +144,8 @@ release: &release
           name: Fetch git tags
           command: git fetch --tags
       - <<: *load_cache
+      # TODO remove this after the build is fixed
+      - <<: *fix_cache
       - run:
           name: Write PGP public key
           command: echo -n "${PGP_PUBLIC}" | base64 -d > /tmp/public.asc


### PR DESCRIPTION
The build in CI fails, because an outdated version of `zio-schema` is used from the cache. It seems that SBT does not update the project for some reason (see also https://github.com/sbt/sbt/issues/2202#issuecomment-286902491).

This change is supposed to work around the issue by deleting `zio-schema` sources from the cache on the `clean_cache` step.