### PR TITLE
Update sbt plugins for the sbt import to work

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,9 +1,11 @@
 addSbtPlugin("com.dwijnand"       % "sbt-dynver"                % "4.0.0")
 addSbtPlugin("com.eed3si9n"       % "sbt-buildinfo"             % "0.10.0")
 addSbtPlugin("com.github.cb372"   % "sbt-explicit-dependencies" % "0.2.16")
-addSbtPlugin("com.jsuereth"       % "sbt-pgp"                   % "1.1.2")
+addSbtPlugin("com.jsuereth"       % "sbt-pgp"                   % "2.0.2")
 addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject"  % "0.6.1")
 addSbtPlugin("org.scala-js"       % "sbt-scalajs"               % "0.6.28")
 addSbtPlugin("org.scalameta"      % "sbt-mdoc"                  % "2.2.13")
 addSbtPlugin("org.scalameta"      % "sbt-scalafmt"              % "2.0.3")
 addSbtPlugin("org.xerial.sbt"     % "sbt-sonatype"              % "3.8")
+addSbtPlugin("ch.epfl.scala"      % "sbt-scalafix"              % "0.9.25")
+


### PR DESCRIPTION
Currently when cloning the project and trying to import it through sbt, the process fails with the following errors:
```
[error] Reference to undefined setting:
[error]
[error]   ThisBuild / scalafixScalaBinaryVersion from Global / scalafixInterfaceProvider ((scalafix.sbt.ScalafixPlugin.globalSettings) ScalafixPlugin.scala:206)
[error]
[error] Use 'last' for the full log.)
```
And
```
[error] Some keys were defined with the same name but different types: 'pgpSigningKey' (sbt.Task[scala.Option[java.lang.String]], scala.Option[Long]), 'signaturesModule' (sbt.Task[com.jsuereth.sbtpgp.GetSignaturesModule], sbt.Task[com.typesafe.sbt.pgp.GetSignaturesModule]), 'pgpSigner' (sbt.Task[com.typesafe.sbt.pgp.PgpSigner], sbt.Task[com.jsuereth.sbtpgp.PgpSigner]), 'checkPgpSignatures' (sbt.Task[com.typesafe.sbt.pgp.SignatureCheckReport], sbt.Task[com.jsuereth.sbtpgp.SignatureCheckReport])
[error] Use 'last' for the full log.)
```

After adding the `sbt-scalafix` plugin and updating the `sbt-pgp` plugin to version `2.0.2`, it solved both of the errors.