### PR TITLE
Compile docs only against 2.13

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -184,7 +184,7 @@ jobs:
     <<: *mdoc
     <<: *machine_ubuntu
     environment:
-      - <<: *scala_212
+      - <<: *scala_213
       - <<: *jdk_8
 
   test_212_jdk8:


### PR DESCRIPTION
Seems like the inference on 2.12 is not so good. We should look into that. For now lets disable mdoc for 2.12 to get the builds passing.